### PR TITLE
multiple definition of `md5_init' and show crypto info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,18 @@ override CFLAGS += -std=gnu99 -Wall
 #LDFLAGS += -fwhole-program
 ifdef USE_CRYPTO_POLARSSL
 override LIBS += -lpolarssl
-override CFLAGS += -DUSE_CRYPTO_POLARSSL 
+override CFLAGS += -DUSE_CRYPTO_POLARSSL
 $(info Compile with PolarSSL.)
+CRYPTO := PolarSSL
 else
 override LIBS += -lssl -lcrypto
 override CFLAGS += -DUSE_CRYPTO_OPENSSL
 $(info Compile with OpenSSL by default. To compile with PolarSSL, run 'make USE_CRYPTO_POLARSSL=true' instead.)
+CRYPTO := OpenSSL
 endif
 ifdef ENABLE_STATIC
 override LIBS += -ldl -lz
-override LDFLAGS += -Wl,-static -static -static-libgcc
+override LDFLAGS += -Wl,-static -static -static-libgcc -s
 endif
 
 all: $(OUT)
@@ -53,12 +55,12 @@ gen/version.c: *.c *.h gen/.build
 	echo '#include "../version.h"' >> $@.tmp
 	echo 'const char* redsocks_version = ' >> $@.tmp
 	if [ -d .git ]; then \
-		echo '"redsocks.git/'`git describe --tags`'"'; \
+		echo '"redsocks.git/'`git describe --tags`' $(CRYPTO)"'; \
 		if [ `git status --porcelain | grep -v -c '^??'` != 0 ]; then \
 			echo '"-unclean"'; \
 		fi \
 	else \
-		echo '"redsocks/$(VERSION)"'; \
+		echo '"redsocks/$(VERSION) $(CRYPTO)"'; \
 	fi >> $@.tmp
 	echo ';' >> $@.tmp
 	mv -f $@.tmp $@

--- a/http-auth.c
+++ b/http-auth.c
@@ -191,7 +191,7 @@ char* digest_authentication_encode(const char *line, const char *user, const cha
 	char response[MD5_HASHLEN * 2 + 1];
 
 	/* A1 = username-value ":" realm-value ":" passwd */
-	md5_init(&ctx);
+	md5_init_rs(&ctx);
 	md5_append(&ctx, (md5_byte_t*)user, strlen(user));
 	md5_append(&ctx, (md5_byte_t*)":", 1);
 	md5_append(&ctx, (md5_byte_t*)realm, strlen(realm));
@@ -201,7 +201,7 @@ char* digest_authentication_encode(const char *line, const char *user, const cha
 	dump_hash(a1buf, hash);
 
 	/* A2 = Method ":" digest-uri-value */
-	md5_init(&ctx);
+	md5_init_rs(&ctx);
 	md5_append(&ctx, (md5_byte_t*)method, strlen(method));
 	md5_append(&ctx, (md5_byte_t*)":", 1);
 	md5_append(&ctx, (md5_byte_t*)path, strlen(path));
@@ -210,7 +210,7 @@ char* digest_authentication_encode(const char *line, const char *user, const cha
 
 	/* qop set: request-digest = H(A1) ":" nonce-value ":" nc-value ":" cnonce-value ":" qop-value ":" H(A2) */
 	/* not set: request-digest = H(A1) ":" nonce-value ":" H(A2) */
-	md5_init(&ctx);
+	md5_init_rs(&ctx);
 	md5_append(&ctx, (md5_byte_t*)a1buf, strlen(a1buf));
 	md5_append(&ctx, (md5_byte_t*)":", 1);
 	md5_append(&ctx, (md5_byte_t*)nonce, strlen(nonce));

--- a/md5.c
+++ b/md5.c
@@ -308,7 +308,7 @@ static void md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	pms->abcd[3] += d;
 }
 
-void md5_init(md5_state_t *pms)
+void md5_init_rs(md5_state_t *pms)
 {
 	pms->count[0] = pms->count[1] = 0;
 	pms->abcd[0] = 0x67452301;

--- a/md5.h
+++ b/md5.h
@@ -76,7 +76,7 @@ extern "C"
 #endif
 
 /* Initialize the algorithm. */
-void md5_init(md5_state_t *pms);
+void md5_init_rs(md5_state_t *pms);
 
 /* Append a string to the message. */
 void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);


### PR DESCRIPTION
fix multiple definition of `md5_init' error when static compile with new PolarSSL(mbedtls);

Show the use of the encryption library in version info `redsocks2 -v`:

redsocks.git/release-0.65-15-g02ffec4 OpenSSL-unclean