### PR TITLE
Fix build for macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,11 @@ base.c: $(CONF)
 
 ifeq ($(OS), Darwin)
 $(OSX_HEADERS_PATH)/net/pfvar.h:
-	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/pfvar.h https://raw.githubusercontent.com/opensource-apple/xnu/master/bsd/net/pfvar.h
+	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/pfvar.h https://raw.githubusercontent.com/apple/darwin-xnu/master/bsd/net/pfvar.h
 $(OSX_HEADERS_PATH)/net/radix.h:
-	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/radix.h https://raw.githubusercontent.com/opensource-apple/xnu/master/bsd/net/radix.h
+	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/radix.h https://raw.githubusercontent.com/apple/darwin-xnu/master/bsd/net/radix.h
 $(OSX_HEADERS_PATH)/libkern/tree.h:
-	mkdir -p $(OSX_HEADERS_PATH)/libkern && curl -o $(OSX_HEADERS_PATH)/libkern/tree.h https://raw.githubusercontent.com/opensource-apple/xnu/master/libkern/libkern/tree.h
+	mkdir -p $(OSX_HEADERS_PATH)/libkern && curl -o $(OSX_HEADERS_PATH)/libkern/tree.h https://raw.githubusercontent.com/apple/darwin-xnu/master/libkern/libkern/tree.h
 endif
 
 $(DEPS): $(OSX_HEADERS) $(SRCS)

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,11 @@ base.c: $(CONF)
 
 ifeq ($(OS), Darwin)
 $(OSX_HEADERS_PATH)/net/pfvar.h:
-	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/pfvar.h https://raw.githubusercontent.com/opensource-apple/xnu/$(OSX_VERSION)/bsd/net/pfvar.h
+	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/pfvar.h https://raw.githubusercontent.com/opensource-apple/xnu/master/bsd/net/pfvar.h
 $(OSX_HEADERS_PATH)/net/radix.h:
-	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/radix.h https://raw.githubusercontent.com/opensource-apple/xnu/$(OSX_VERSION)/bsd/net/radix.h
+	mkdir -p $(OSX_HEADERS_PATH)/net && curl -o $(OSX_HEADERS_PATH)/net/radix.h https://raw.githubusercontent.com/opensource-apple/xnu/master/bsd/net/radix.h
 $(OSX_HEADERS_PATH)/libkern/tree.h:
-	mkdir -p $(OSX_HEADERS_PATH)/libkern && curl -o $(OSX_HEADERS_PATH)/libkern/tree.h https://raw.githubusercontent.com/opensource-apple/xnu/$(OSX_VERSION)/libkern/libkern/tree.h
+	mkdir -p $(OSX_HEADERS_PATH)/libkern && curl -o $(OSX_HEADERS_PATH)/libkern/tree.h https://raw.githubusercontent.com/opensource-apple/xnu/master/libkern/libkern/tree.h
 endif
 
 $(DEPS): $(OSX_HEADERS) $(SRCS)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ brew install openssl libevent
 Makefile include the folder of openssl headers and lib installed by brew.
 
 To build with PF and run on MacOS, you will need some pf headers that are not included with a standard MacOS installation.
-You can find them on this repository : https://github.com/opensource-apple/xnu
+You can find them on this repository : https://github.com/apple/darwin-xnu
 And the Makefile will going find this file for you
 
 Configurations

--- a/base.c
+++ b/base.c
@@ -198,9 +198,9 @@ static int getdestaddr_pf(
 	char clientaddr_str[INET6_ADDRSTRLEN], bindaddr_str[INET6_ADDRSTRLEN];
 
 	memset(&nl, 0, sizeof(struct pfioc_natlook));
-	nl.saddr.v4.s_addr = client->sin_addr.s_addr;
+	nl.saddr.v4addr.s_addr = client->sin_addr.s_addr;
 	nl.sport = client->sin_port;
-	nl.daddr.v4.s_addr = bindaddr->sin_addr.s_addr;
+	nl.daddr.v4addr.s_addr = bindaddr->sin_addr.s_addr;
 	nl.dport = bindaddr->sin_port;
 	nl.af = AF_INET;
 	nl.proto = IPPROTO_TCP;
@@ -219,7 +219,7 @@ static int getdestaddr_pf(
 	}
 	destaddr->sin_family = AF_INET;
 	destaddr->sin_port = nl.rdport;
-	destaddr->sin_addr = nl.rdaddr.v4;
+	destaddr->sin_addr = nl.rdaddr.v4addr;
 	return 0;
 
 fail:


### PR DESCRIPTION
PF header file urls in Makefile are outdated, faild to build on macOS mojave.

Update this urls to make build success.