### PR TITLE
Fix UDP source address compare

### DIFF
--- a/redudp.c
+++ b/redudp.c
@@ -413,7 +413,7 @@ static void redudp_pkt_from_client(int fd, short what, void *_arg)
 
     // TODO: this lookup may be SLOOOOOW.
     list_for_each_entry(tmp, &self->clients, list) {
-        if (0 == memcmp(&clientaddr, &tmp->clientaddr, sizeof(clientaddr))) {
+        if (0 == sockaddr_storage_compare(&clientaddr, &tmp->clientaddr)) {
             client = tmp;
             break;
         }

--- a/utils.c
+++ b/utils.c
@@ -573,5 +573,13 @@ void replace_eventcb(struct bufferevent * buffev, bufferevent_event_cb eventcb)
 #endif
 }
 
+int sockaddr_storage_compare(struct sockaddr_storage *lhs, struct sockaddr_storage *rhs)
+{
+    size_t lhs_size = addr_size(lhs);
+    size_t rhs_size = addr_size(rhs);
+    size_t larger_size = (lhs_size > rhs_size) ? lhs_size : rhs_size;
+    return memcmp(lhs, rhs, larger_size);
+}
+
 
 /* vim:set tabstop=4 softtabstop=4 shiftwidth=4: */

--- a/utils.h
+++ b/utils.h
@@ -102,6 +102,8 @@ void replace_readcb(struct bufferevent * buffev, bufferevent_data_cb readcb);
 void replace_writecb(struct bufferevent * buffev, bufferevent_data_cb writecb);
 void replace_eventcb(struct bufferevent * buffev, bufferevent_event_cb eventcb);
 
+int sockaddr_storage_compare(struct sockaddr_storage *lhs, struct sockaddr_storage *rhs);
+
 #define event_fmt_str "%s|%s|%s|%s|%s|%s|0x%x"
 #define event_fmt(what) \
 				(what) & BEV_EVENT_READING ? "READING" : "0", \


### PR DESCRIPTION
When comparing the client address, the paddings in the `sockaddr_storage` is also compared as well. Because the paddings are not necessarily zeroed, the comparison can give non-zero result when the addresses are the same. This can cause every single outgoing UDP packet to have different source ports when being proxied.

First time contributing to projects, please let me know if I have done anything wrong. Cheers!