### PR TITLE
added support for FreeBSD/OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ endif
 ifeq ($(OS), FreeBSD)
 override CFLAGS +=-I/usr/local/include -L/usr/local//lib
 endif
+ifeq ($(OS), OpenBSD)
+override CFLAGS +=-I/usr/local/include -L/usr/local//lib #same as FreeBSD
+endif
 ifeq ($(OS), Darwin)
 override CFLAGS +=-I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib
 SHELL := /bin/bash
@@ -52,7 +55,10 @@ override CFLAGS += -DENABLE_HTTPS_PROXY
 override FEATURES += ENABLE_HTTPS_PROXY
 $(info Compile with HTTPS proxy enabled.)
 endif
-override LIBS += -lssl -lcrypto -ldl
+override LIBS += -lssl -lcrypto
+ifneq ($(OS), OpenBSD)
+override LIBS += -ldl
+endif
 override CFLAGS += -DUSE_CRYPTO_OPENSSL
 endif
 ifdef ENABLE_STATIC
@@ -79,6 +85,9 @@ $(CONF):
 	OpenBSD) \
 		echo "#define USE_PF" >$(CONF) \
 		;; \
+	NetBSD) \
+                echo "#define USE_PF" >$(CONF) \
+                ;; \
 	Darwin) \
 		echo -e "#define USE_PF\n#define _APPLE_" >$(CONF) \
 		;; \

--- a/base.c
+++ b/base.c
@@ -95,7 +95,7 @@ static base_instance instance = {
 	.log_info = false,
 };
 
-#if defined __FreeBSD__ || defined USE_PF
+#if defined __FreeBSD__ || defined USE_PF  || defined __OpenBSD__ || defined __NetBSD__
 static int redir_open_private(const char *fname, int flags)
 {
 	int fd = open(fname, flags);

--- a/libc-compat.h
+++ b/libc-compat.h
@@ -42,7 +42,7 @@
 #   define SOL_IP IPPROTO_IP
 #endif
 
-#ifdef __FreeBSD__
+#if defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__
 #ifndef INADDR_LOOPBACK
 #   warning Using hardcoded value for INADDR_LOOPBACK for FreeBSD.
 #   define INADDR_LOOPBACK		0x7F000001

--- a/redsocks.c
+++ b/redsocks.c
@@ -1022,7 +1022,7 @@ static int redsocks_init_instance(redsocks_instance *instance)
     if (apply_reuseport(fd))
         log_error(LOG_WARNING, "Continue without SO_REUSEPORT enabled");
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
     bindaddr_len = instance->config.bindaddr.ss_len > 0 ? instance->config.bindaddr.ss_len : sizeof(instance->config.bindaddr);
 #else
     bindaddr_len = sizeof(instance->config.bindaddr);

--- a/socks5-udp.c
+++ b/socks5-udp.c
@@ -312,7 +312,11 @@ static void socks5_read_assoc_reply(struct bufferevent *buffev, void *_arg)
         goto fail;
     }
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    error = connect(fd, (struct sockaddr*)&socks5client->udprelayaddr, sizeof(struct sockaddr_in));
+#else
     error = connect(fd, (struct sockaddr*)&socks5client->udprelayaddr, sizeof(socks5client->udprelayaddr));
+#endif
     if (error) {
         redudp_log_errno(client, LOG_NOTICE, "connect");
         goto fail;

--- a/tcpdns.c
+++ b/tcpdns.c
@@ -463,7 +463,7 @@ static int tcpdns_init_instance(tcpdns_instance *instance)
     if (apply_reuseport(fd))
         log_error(LOG_WARNING, "Continue without SO_REUSEPORT enabled");
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
     bindaddr_len = instance->config.bindaddr.ss_len > 0 ? instance->config.bindaddr.ss_len : sizeof(instance->config.bindaddr);
 #else
     bindaddr_len = sizeof(instance->config.bindaddr);


### PR DESCRIPTION
Added support for FreeBSD/OpenBSD (https://github.com/semigodking/redsocks/issues/200).

# FreeBSD
Tested with FreeBSD 14.0, ipfw, with `redirector=generic`. 

The main point is setting "IP_BINDANY" to avoid os error 49 (Can't assign requested address) at bound_udp_get(). Also, `sizeof(struct sockaddr_in)` seems to be required to avoid "Invalid address" error. 

This is my script for ipfw/ifconfig.
```
kldload ipfw
fwcmd=ipfw
ifconfig em0 alias 10.0.2.25 netmask 0xffffff00
$fwcmd add 100 allow all from any to any via lo0
$fwcmd add 500 fwd 127.0.0.1,22222 tcp from 10.0.2.25 to any
$fwcmd add 600 fwd 127.0.0.1,22222 udp from 10.0.2.25 to any
$fwcmd add 700 allow ip from any to any
```

FreeBSD has firewalls other than IPFW, i.e. pf and ipfilter (ipf). 

pf partially worked but destination addresses were obtained as the transparent proxy port (127.0.0.1:22222), useless in actual cases.  For TCP, there is a way to get the original destination, but this seems not work for UDP (https://stackoverflow.com/questions/46675715/how-do-i-get-the-original-destination-ip-of-a-redirected-connection-with-pf-on-f#comment119982054_56689694).

FYI, this is my pf configiration. 
```
rdr pass on lo0 proto {tcp, udp} from 10.0.2.25 -> 127.0.0.1 port 22222
pass out quick route-to lo0 from 10.0.2.25
pass
```

For ipfilter, I couldn't figure out how to set it up for transparent proxy (though it seems supported by redsocks according to documentation).

I also tried pfSense, but strangely, only UDP worked. (TCP packets won't be received by redsocks). 

# OpenBSD
Tested with OpenBSD 7.5 and pf, `redirector=generic`.

I added 10.0.2.25 as before, and this is the configuration.
```
pass        # establish keep-state
pass in quick proto {tcp, udp} from 10.0.2.25 to ! 10.0.2.25 divert-to 127.0.0.1 port 22222
pass out quick proto {tcp, udp} from 10.0.2.25 route-to lo0
```
To make it work, I added some options like IP_RECVDSTADDR for sockets, according to man page documentation on `divert-to` syntax. https://github.com/ge9/redsocks/commit/65fa263c3ed594531a7d0ae5d5ffeb8bd998602a  
Currently it support only IPv4. (IPv6 udp relay seems not supported by redsocks itself)

Also, similarly to FreeBSD, SO_BINDANY is set to avoid os error 49.

If we use `rdr-to` instead of `divert-to` here, the destination addresses are obtained as 127.0.0.1:22222, much like the behavior of FreeBSD's pf.

 `redirector=pf` doesn't work correctly for TCP, because it's for FreeBSD's pf.

I also tried NetBSD which OpenBSD originates from, but it seems that there are no `divert-to` in NetBSD's pf.
