### PR TITLE
Fix: GCC 14 pointer type-checking error during build

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -266,7 +266,7 @@ struct bufferevent* red_connect_relay_ssl(const char *ifname,
     if (timeout_write)
         bufferevent_set_timeouts(underlying, NULL, timeout_write);
 
-    error = connect(relay_fd, addr, addr_size(addr));
+    error = connect(relay_fd, (struct sockaddr *)addr, addr_size(addr));
     if (error && errno != EINPROGRESS) {
         log_errno(LOG_NOTICE, "connect");
         goto fail;


### PR DESCRIPTION
Upgrade to GCC 14 convert type-checking warnings to errors [ref](https://gcc.gnu.org/gcc-14/porting_to.html).

Compilation error message with GCC 14:
```
cc -fPIC -O3 -DDISABLE_SHADOWSOCKS -D_BSD_SOURCE -D_DEFAULT_SOURCE -Wall -std=c99 -D_XOPEN_SOURCE=600 -DENABLE_HTTPS_PROXY -DUSE_CRYPTO_OPENSSL   -c -o utils.o utils.c
utils.c: In function ‘red_connect_relay_ssl’:
utils.c:269:31: error: passing argument 2 of ‘connect’ from incompatible pointer type [-Wincompatible-pointer-types]
  269 |     error = connect(relay_fd, addr, addr_size(addr));
      |                               ^~~~
      |                               |
      |                               struct sockaddr_storage *
In file included from utils.c:22:
/usr/include/sys/socket.h:126:52: note: expected ‘const struct sockaddr *’ but argument is of type ‘struct sockaddr_storage *’
  126 | extern int connect (int __fd, __CONST_SOCKADDR_ARG __addr, socklen_t __len);
      |                                                    ^
make: *** [<builtin>: utils.o] Error 1
```