### PR TITLE
revert a change in DST.ADDR and DST.PORT of UDP Associate request (#210)

### DIFF
--- a/socks5-udp.c
+++ b/socks5-udp.c
@@ -51,7 +51,10 @@ static struct evbuffer* socks5_mkpassword_plain_wrapper(void *p)
 
 static struct evbuffer* socks5_mkassociate(void *p)
 {
-    return socks5_mkcommand_plain(socks5_cmd_udp_associate, p);
+    struct sockaddr_storage sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.ss_family = ((const struct sockaddr_storage *)p)->ss_family;
+    return socks5_mkcommand_plain(socks5_cmd_udp_associate, &sa);
 }
 
 static void socks5_fill_preamble(


### PR DESCRIPTION
Reverts [this change](https://github.com/semigodking/redsocks/commit/c8e1e6c4c1d623b2e540528ac9efd06dde952006#diff-c5eec5d34c1236a88e49266049e94d26dbce900422408ddb21217b85c8396ad5R54) to fix #210. 
