### PR TITLE
Fix IPv6 bind() error in bound_udp_get()

### DIFF
--- a/redudp.c
+++ b/redudp.c
@@ -164,7 +164,17 @@ static int bound_udp_get(const struct sockaddr *addr)
         goto fail;
     }
 
-    if (0 != bind(node->fd, (struct sockaddr*)addr, sizeof(*addr))) {
+    socklen_t bindaddr_len;
+#ifdef SOL_IPV6
+    if (addr->sa_family == AF_INET) {
+#endif
+        bindaddr_len = sizeof(struct sockaddr_in);
+#ifdef SOL_IPV6
+    } else {
+        bindaddr_len = sizeof(struct sockaddr_in6);
+    }
+#endif
+    if (0 != bind(node->fd, (struct sockaddr*)addr, bindaddr_len)) {
         log_errno(LOG_ERR, "bind");
         goto fail;
     }


### PR DESCRIPTION
In IPv6, bind() in bound_udp_get() will cause this error.

> 1765470562.522208 err redudp.c:168 bound_udp_get(...) bind: Invalid argument
1765470562.522238 warning redudp.c:315 redudp_fwd_pkt_to_sender(...) [[fd00::2222]:53568->[2600:1f16:8c5:101:80b:b58b:828:8df4]:3478]: bound_udp_get failure

This comes from the third argument of bind().
This PR changes the length according to IP versions. My smallest IPv6 testing started working after this change.